### PR TITLE
ff bug fix, a11y sign-in fix

### DIFF
--- a/public/buttons.styl
+++ b/public/buttons.styl
@@ -87,6 +87,7 @@ button
     outline: none
 
 .cta-buttons
+  position: relative
   margin-top: 1rem
   button,
   .button

--- a/public/includes/header.styl
+++ b/public/includes/header.styl
@@ -32,6 +32,7 @@ header
   .user
     display: inline-block
     padding-right: 5px
+    border: none
     img
       width: 28px
       height: auto

--- a/templates/includes/cta-buttons.jade
+++ b/templates/includes/cta-buttons.jade
@@ -3,7 +3,7 @@ section.cta-buttons
 
   button.button.has-emoji.opens-pop-over(click=@toggleCtaPop) Start a New Project
     .emoji.sparkles
-    = @ctaPop
+  = @ctaPop
 
   a(href="https://glitch.com/edit/" data-track="cta → resume coding" class=@hiddenUnlessIsSignedIn)
     .button.button-cta Resume Coding

--- a/templates/includes/header.jade
+++ b/templates/includes/header.jade
@@ -12,11 +12,11 @@ header(role="banner")
       input.search-input(name="q" id="search-projects" placeholder="bots, apps, users" value=@application.searchQuery)
 
     span(class=@hiddenIfSignedIn)
-      .button.button-small.opens-pop-over(click=@toggleSignInPopVisible) Sign in
+      button.button.button-small.opens-pop-over(click=@toggleSignInPopVisible) Sign in
       span(class=@hiddenUnlessSignInPopVisible)
         = SignInPopPresenter(@.application).template
     .user-options-pop-button.opens-pop-over(class=@hiddenUnlessSignedIn click=@toggleUserOptionsPopVisible data-tooltip="User options" data-tooltip-right=true)
-      .user
+      button.user
         img(src=@userAvatar width=30 height=30 alt="User options")
         span.down-arrow.icon
       = UserOptionsPopPresenter(@.application).template


### PR DESCRIPTION
so according to the html spec there should be no active elements in a button, so dialogs need to be siblings (see https://github.com/webcompat/web-bugs/issues/9726#issuecomment-327963090)

notes on files/updates in glitch editor:
* https://glitch.com/edit/#!/community?path=templates/includes/cta-buttons.jade:6:2
  - make = template outside of button
* https://glitch.com/edit/#!/community?path=public/buttons.styl:90:20
  - cta-buttons -> position: relative
* https://glitch.com/edit/#!/community?path=templates/includes/header.jade:17:8
  - changed sign in div to button element for keyboard access
  - changed user avater (when signed in) div to button for keyboard access
* https://glitch.com/edit/#!/community?path=public/includes/header.styl:35:16
  - removed border from signed in user avatar button